### PR TITLE
Add observation label to smart chamber output

### DIFF
--- a/R/read_data_functions.R
+++ b/R/read_data_functions.R
@@ -212,6 +212,7 @@ ffi_read_EGM4 <- function(file, year, tz = "UTC") {
 #' @note These files are in \href{https://www.json.org/json-en.html}{JSON} format.
 #' See also \url{https://www.licor.com/env/products/soil-flux/smart-chamber}.
 #' @export
+#' @author Ben Bond-Lamberty
 #' @examples
 #' f <- system.file("extdata/LI8200-01S.json", package = "fluxfinder")
 #' dat <- ffi_read_LIsmartchamber(f) # returns 240 rows

--- a/R/read_data_functions.R
+++ b/R/read_data_functions.R
@@ -230,7 +230,9 @@ ffi_read_LIsmartchamber <- function(file, concentrations = TRUE) {
     # Loop through all repetitions within an observation
     for(rep in seq_along(dat$reps)) {
       # Info on observation and rep
-      rep_df <- data.frame(obs = obs, rep = rep)
+      rep_df <- data.frame(label = names(dat_raw$datasets[[obs]]),
+                           obs = obs,
+                           rep = rep)
 
       repdat <- dat$reps[[rep]]
 

--- a/man/ffi_read_LIsmartchamber.Rd
+++ b/man/ffi_read_LIsmartchamber.Rd
@@ -27,3 +27,6 @@ f <- system.file("extdata/LI8200-01S.json", package = "fluxfinder")
 dat <- ffi_read_LIsmartchamber(f) # returns 240 rows
 ffi_read_LIsmartchamber(f, concentrations = FALSE) # only 4 rows
 }
+\author{
+Ben Bond-Lamberty
+}


### PR DESCRIPTION
Add the observation label, i.e. the identifier entered by users, into the `ffi_read_LIsmartchamber` output:

```r
f <- system.file("extdata/LI8200-01S.json", package = "fluxfinder")
ffi_read_LIsmartchamber(f, concentrations = FALSE)

Reading observation 1
Reading observation 2
    label obs rep  Chamber Version InstrumentModel
1 1    47   1   1 82s-1050     1.1         LI-7810
1 2    47   1   2 82s-1050     1.1         LI-7810
2 1    48   2   1 82s-1050     1.1         LI-7810
2 2    48   2   2 82s-1050     1.1         LI-7810
```

Here "47" and "48" (`label` column) are the TEMPEST collar numbers.

Problem noted by @robertapeixoto and @wilsonsj100 in #60 