### PR TITLE
C0 band

### DIFF
--- a/R/models.R
+++ b/R/models.R
@@ -253,12 +253,19 @@ ffi_compute_fluxes <- function(data,
   # passing volume and area?
   f <- function(x, ...) {
     x$.norm_time <- ffi_normalize_time(x[,time_column], normalize_time)
+
+    # Sanity checks
+    min_time <- min(x[,time_column])
+    max_time <- max(x[,time_column])
+    if(dead_band >= max_time) stop("dead_band is larger than given time window")
+    if(c0_band >= max_time) stop("c0_band is larger than given time window")
+
     c0 <- mean(x[x$.norm_time <= c0_band, gas_column])
     x <- x[x$.norm_time >= dead_band,] # exclude dead band data
     out <- fit_function(x$.norm_time, x[,gas_column], ...)
     out[time_column] <- mean(x[,time_column])
-    out[paste0(time_column, "_min")] <- min(x[,time_column])
-    out[paste0(time_column, "_max")] <- max(x[,time_column])
+    out[paste0(time_column, "_min")] <- min_time
+    out[paste0(time_column, "_max")] <- max_time
     out$c0 <- c0
     return(out)
   }

--- a/man/ffi_compute_fluxes.Rd
+++ b/man/ffi_compute_fluxes.Rd
@@ -10,6 +10,7 @@ ffi_compute_fluxes(
   time_column,
   gas_column,
   dead_band = 0,
+  c0_band = 5,
   normalize_time = TRUE,
   fit_function = ffi_fit_models,
   ...
@@ -29,6 +30,9 @@ pass NULL to run with no grouping}
 \item{dead_band}{Length of dead band, the equilibration period at the
 beginning of the time series during which data are ignore, in seconds (numeric)}
 
+\item{c0_band}{Length of the period at the beginning of the time series
+that is used to determine an ambient or pre-flux concentration, in second (numeric)}
+
 \item{normalize_time}{Normalize the values so that first is zero? Logical}
 
 \item{fit_function}{Optional flux-fit function;
@@ -40,7 +44,8 @@ default is \code{\link{ffi_fit_models}}}
 A data.frame with one row per \code{group_column} value. It will
 always include the mean, minimum, and maximum values of \code{time_column}
 for that group, but other
-columns depend on what is returned by the \code{fit_function}.
+columns depend on what is returned by the \code{fit_function}. The \code{c0} column
+is the average concentration over the first \code{c0_band} in seconds.
 }
 \description{
 Compute fluxes for multiple groups (measurements)

--- a/tests/testthat/test-models.R
+++ b/tests/testthat/test-models.R
@@ -39,7 +39,7 @@ test_that("ffi_compute_fluxes works", {
   ff <- function(a, b) data.frame(x = 1) # dummy fit function
 
   # Normalize times
-  out <- ffi_compute_fluxes(x, "Plot", "time", "conc",
+  out <- ffi_compute_fluxes(x, "Plot", "time", "conc", c0_band = 1,
                             fit_function = ff, normalize_time = TRUE)
   expect_s3_class(out, "data.frame")
   expect_identical(out$Plot, plots) # one row per plot
@@ -47,8 +47,14 @@ test_that("ffi_compute_fluxes works", {
   expect_identical(out$time_min, rep(min(times), nrow(out))) # min of raw times
   expect_identical(out$time_max, rep(max(times), nrow(out))) # max of raw times
 
+  # Catches bad band values
+  expect_error(ffi_compute_fluxes(cars, group_column = NULL, "speed", "dist", dead_band = 6000),
+                regexp = "dead_band is larger than")
+  expect_error(ffi_compute_fluxes(cars, group_column = NULL, "speed", "dist", c0_band = 6000),
+               regexp = "c0_band is larger than")
+
   # Raw times
-  out <- ffi_compute_fluxes(x, "Plot", "time", "conc",
+  out <- ffi_compute_fluxes(x, "Plot", "time", "conc", c0_band = 1,
                             fit_function = ff, normalize_time = FALSE)
   expect_identical(out$Plot, plots) # one row per plot
   expect_identical(out$time, rep(mean(times), nrow(out))) # mean of raw times
@@ -56,7 +62,7 @@ test_that("ffi_compute_fluxes works", {
   expect_identical(out$time_max, rep(max(times), nrow(out))) # max of raw times
 
   # Passing NULL for the group column should return a single row
-  out <- ffi_compute_fluxes(x, NULL, "time", "conc",
+  out <- ffi_compute_fluxes(x, NULL, "time", "conc", c0_band = 1,
                             fit_function = ff, normalize_time = TRUE)
   expect_s3_class(out, "data.frame")
   expect_identical(nrow(out), 1L) # one row


### PR DESCRIPTION
This pull request adds a new parameter to ffi_compute_fluxes() that calculates an average concentration (c0) that you can set the timing of. This could calculate the average concentration of the first few measurements. @nickdward let us know if this is helpful and what you were looking for. 