### PR TITLE
ffi_qaqc fix

### DIFF
--- a/R/metadata.R
+++ b/R/metadata.R
@@ -36,10 +36,10 @@
 #' # has no match
 #'
 #' # This generates an error because of overlapping timestamps:
-#' \try{
+#' try({
 #' s_t <- c("13:00:00", "13:01:00")
 #' ffi_metadata_match(d_t, s_d, s_t, ol)
-#' }
+#' })
 ffi_metadata_match <- function(data_timestamps,
                                start_dates, start_times,
                                obs_lengths) {

--- a/R/qaqc.R
+++ b/R/qaqc.R
@@ -41,6 +41,7 @@ ffi_qaqc <- function(flux_data,
                             output_file = output_file,
                             output_dir = output_dir,
                             knit_root_dir = output_dir,
+                            intermediates_dir = output_dir,
                             quiet = ffi_isquiet(),
                             params = list(flux_data = tf_flux_data,
                                           group_column = group_column))

--- a/man/ffi_metadata_match.Rd
+++ b/man/ffi_metadata_match.Rd
@@ -47,8 +47,8 @@ ffi_metadata_match(d_t, s_d, s_t, ol)
 # has no match
 
 # This generates an error because of overlapping timestamps:
-\dontrun{
+try({
 s_t <- c("13:00:00", "13:01:00")
 ffi_metadata_match(d_t, s_d, s_t, ol)
-}
+})
 }


### PR DESCRIPTION
So, the problem documented in #104 was

1. CRAN's R CMD CHECK runs the function examples
2. The `ffi_qaqc()` example runs (`#' x <- ffi_qaqc(fd, ...`
3. `rmarkdown::render()` is called within ffi_qaqc
4. render generates some intermediate products in (by default) the working directory
5. CRAN errors because you're not allowed to write there

This PR adds `intermediates_dir = output_dir` to the render call, which _should_ fix things. I also fixed a syntax problem in the `ffi_metadata_match` documentation 

Closes #104 
